### PR TITLE
fix: halting when executing some commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,8 @@ pub fn execute(input: String) -> io::Result<()> {
         "type" => builtins::cmd_type(args),
         _ => {
             if let Some(_) = get_bin_path(cmd) {
-                let output = Command::new(cmd).args(args).output()?;
+                let process = Command::new(cmd).args(args).spawn()?;
+                let output = process.wait_with_output()?;
 
                 io::stdout().write_all(&output.stdout)?;
                 io::stderr().write_all(&output.stderr)?;


### PR DESCRIPTION
Execute commands as a child process then wait for output. This solves the halting issue with commands like `vim`.

Fixes #1.